### PR TITLE
New Azalia subid for Matebook X: 320119e5

### DIFF
--- a/sys/dev/pci/azalia_codec.c
+++ b/sys/dev/pci/azalia_codec.c
@@ -155,7 +155,8 @@ azalia_codec_init_vtbl(codec_t *this)
 		break;
 	case 0x10ec0298:
 		this->name = "Realtek ALC298";
-		if (this->subid == 0x320019e5)		/* Huawei Matebook X */
+		if (this->subid == 0x320019e5 ||
+		    this->subid == 0x320119e5)		/* Huawei Matebook X */
 			this->qrks |= AZ_QRK_DOLBY;
 		break;
 	case 0x10ec0660:


### PR DESCRIPTION
Recently (thanks to your review) I bought MateBook X. I applied "Azalia codec" patch you made (outstanding job) but it didn't work. I realized `subid` in my MateBook is different. With changed `subid` it's fine now.