### PR TITLE
Fix off-by-one error in hid_unit_exp

### DIFF
--- a/sys/dev/hid/hid.c
+++ b/sys/dev/hid/hid.c
@@ -666,7 +666,7 @@ hid_unit_exp(int8_t exp)
 		-8, -7, -6, -5, -4, -3, -2, -1,
 	};
 
-	if (exp > sizeof(mults))
+	if (exp >= sizeof(mults))
 		return 0;
 
 	return mults[exp];


### PR DESCRIPTION
Fixes an off-by-one error that will cause hid_unit_exp to return undefined value when called with exp=16